### PR TITLE
niv nixpkgs: update 29eddfc3 -> 0b1657a2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -13,13 +13,14 @@
     },
     "nixpkgs": {
         "branch": "release-20.03",
+        "description": "Nix Packages collection",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "29eddfc36d720dcc4822581175217543b387b1e8",
-        "sha256": "1gqv2m7plkladd3va664xyqb962pqs4pizzibvkm1nh0f4rfpxvy",
+        "rev": "0b1657a27810f0f39db56b635eb792b6d397e6b2",
+        "sha256": "0n4yrz4mybvw2a3s79hjz1ddv369yp1ajg7gm2kwb18syi28f13a",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/29eddfc36d720dcc4822581175217543b387b1e8.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0b1657a27810f0f39db56b635eb792b6d397e6b2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-static": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Commits: [NixOS/nixpkgs@29eddfc3...0b1657a2](https://github.com/NixOS/nixpkgs/compare/29eddfc36d720dcc4822581175217543b387b1e8...0b1657a27810f0f39db56b635eb792b6d397e6b2)

* [`42cca0d8`](https://github.com/NixOS/nixpkgs/commit/42cca0d8ea689ba0b7fc390422c7f0925c5c0eac) mariadb-connector-c: add mysqlclient.pc pkgconfig symlink
* [`5e24f4b3`](https://github.com/NixOS/nixpkgs/commit/5e24f4b3b3a5439a67f9027d40e0889070232f44) openssl(_1_1): patch CVE-2019-1551
* [`0e5ef8c4`](https://github.com/NixOS/nixpkgs/commit/0e5ef8c4709e44dfdf22f742c1ebf92d2420e1cf) openssl: 1.1.1d -> 1.1.1f
* [`3b383195`](https://github.com/NixOS/nixpkgs/commit/3b3831957fe82543edf695a2b5dd0dc9db350328) go_1_14: 1.14 -> 1.14.1
* [`6e14cf0e`](https://github.com/NixOS/nixpkgs/commit/6e14cf0e620f49510680b106cba1ebdee98bd3be) itstool: fix double-shebang issue on macOS
* [`7601af23`](https://github.com/NixOS/nixpkgs/commit/7601af232ba8bdae2fa28329e9b7e1776dfc9272) itstool: use wrapPython to fix double shebang on macOS
* [`d815dc4b`](https://github.com/NixOS/nixpkgs/commit/d815dc4b681596db53400ecc983da63d087275d5) Merge NixOS/nixpkgs#84273: gnutls: 3.6.12 -> 3.6.13 [security]
* [`6570f2ae`](https://github.com/NixOS/nixpkgs/commit/6570f2aec57c8e78e9d0902affc2e97562925b43) haskellPackages.amqp-utils: fix amqp-0.19 dependency
* [`3c700b8a`](https://github.com/NixOS/nixpkgs/commit/3c700b8aa669376d4fdf9567e452a1898fdcd3a6) cargo-make: 0.30.2 -> 0.30.4
* [`4291ef9b`](https://github.com/NixOS/nixpkgs/commit/4291ef9bb6711f4347df0dfc8b613fdc04895ba0) prometheus-wireguard-exporter: 3.2.4 -> 3.3.0
* [`c5a806cf`](https://github.com/NixOS/nixpkgs/commit/c5a806cfc05696ae45a48891e25e10c28b61f104) haskellPackages.pandoc-crossref: downgrade to latest working
* [`5b340635`](https://github.com/NixOS/nixpkgs/commit/5b3406359436dc51d65d2916767f25b2e710c391) tmuxPlugins: upgrade all to latest
