### PR TITLE
niv nixpkgs: update 708cb6b3 -> 0f920b05

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "708cb6b307b04ad862cc50de792e57e7a4a8bb5a",
-        "sha256": "0fjwv9sxl3j6z0jszaznvz891mn44fz6lqxsa2fkx9xi5mkz63jm",
+        "rev": "0f920b05cbcdb8c0f3c5c4a8ea29f1f0065c7033",
+        "sha256": "0bmsv2yfvpifiry3hrv0srf5ax0rh5ffbc5l7v46v8wajjxdrny9",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/708cb6b307b04ad862cc50de792e57e7a4a8bb5a.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0f920b05cbcdb8c0f3c5c4a8ea29f1f0065c7033.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-static": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Commits: [NixOS/nixpkgs@708cb6b3...0f920b05](https://github.com/NixOS/nixpkgs/compare/708cb6b307b04ad862cc50de792e57e7a4a8bb5a...0f920b05cbcdb8c0f3c5c4a8ea29f1f0065c7033)

* [`ee47f528`](https://github.com/NixOS/nixpkgs/commit/ee47f5285f9c162c6afaa425a0f67ae8ca90732a) ceph: 14.2.6 -> 14.2.7
* [`74ee45c4`](https://github.com/NixOS/nixpkgs/commit/74ee45c435dc2886ab2311e213c466eefcb52b5f) ceph: 14.2.7 -> 14.2.8
* [`637325d6`](https://github.com/NixOS/nixpkgs/commit/637325d63f21480c23f3e61f98772390c446fd97) nixos/tests/ceph: Fix pg number to power of 2
* [`6be1626d`](https://github.com/NixOS/nixpkgs/commit/6be1626da54d9ee3748491e59d957965a8b19caf) nixos: kafka test: fix building for other arches
* [`1610b4ab`](https://github.com/NixOS/nixpkgs/commit/1610b4ab21896090381a562eb184aaea3aed8465) coqPackages.dpdgraph: fix build with OCaml ≥ 4.08
* [`26702dfb`](https://github.com/NixOS/nixpkgs/commit/26702dfb585cac4fe3816d301364e8c8a8b855c6) wdisplays: 2020-01-12 -> 2020-03-15
* [`56ff1184`](https://github.com/NixOS/nixpkgs/commit/56ff118499c3dfb99975674efa6820a6894c833b) packer: 1.5.4 -> 1.5.5
* [`9325edaa`](https://github.com/NixOS/nixpkgs/commit/9325edaa1eb6b462ac662356bc80a8074160c09a) linuxPackages.bpftrace: 0.9.3 -> 0.9.4
* [`96e35bf2`](https://github.com/NixOS/nixpkgs/commit/96e35bf2a0b78e1517c9946c76fcb6094a577aff) EmptyEpsilon: 2020.03.22 -> 2020.04.09
* [`0182312e`](https://github.com/NixOS/nixpkgs/commit/0182312e119121c27f59455ed0e35ccb6cc72b1e) mnemosyne: add googletrans and gtts python dependencies
* [`c2d20926`](https://github.com/NixOS/nixpkgs/commit/c2d209265d13ea9da4b1d623798b84aafa65176e) pythonPackages.googletrans: init at 2.4.0
* [`93e93f82`](https://github.com/NixOS/nixpkgs/commit/93e93f82e619af73367731718f67f98822ad8d0b) pythonPackages.gtts: init at 2.1.1
* [`ec099df0`](https://github.com/NixOS/nixpkgs/commit/ec099df0935adf67c6a2dfcd91f09553143faf16) mnemosyne: Fix 'Could not find Qt' segfault
* [`7a0cb9c3`](https://github.com/NixOS/nixpkgs/commit/7a0cb9c305eef194a2f8884240e10df9f662fae9) mnemosyne: Add pyopengl to silence OpenGL warning
* [`2fd2e031`](https://github.com/NixOS/nixpkgs/commit/2fd2e031a342c7ae117e5b63a9838ad2f41fdd30) mnemosyne: Install mnemosyne.desktop
* [`be8daae1`](https://github.com/NixOS/nixpkgs/commit/be8daae10cae108907b5ba0189a90900b3635bf4) linux: 4.4.218 -> 4.4.219
* [`585f6510`](https://github.com/NixOS/nixpkgs/commit/585f651020c49e857266392502e6342bac0a5567) linux: 4.14.175 -> 4.14.176
* [`788dd86a`](https://github.com/NixOS/nixpkgs/commit/788dd86a623439e07ddf4bf247671becfa15a9e1) linux: 4.19.114 -> 4.19.115
* [`44537fa3`](https://github.com/NixOS/nixpkgs/commit/44537fa3f495f698398fe49bbcbbf914aada2eb9) linux: 4.9.218 -> 4.9.219
* [`bab08a49`](https://github.com/NixOS/nixpkgs/commit/bab08a49dfb42d4aed5074cd4abc23b567ba81af) linux: 5.4.31 -> 5.4.32
* [`cb8b71c6`](https://github.com/NixOS/nixpkgs/commit/cb8b71c6455b1017eb3aeeae35f92f0e4f4adb45) linux: 5.5.16 -> 5.5.17
* [`ef7f4788`](https://github.com/NixOS/nixpkgs/commit/ef7f4788c7e58bab9220268a40c0bef57284b8e4) android-studio: Fix the license (unfree)
* [`9f0f06ac`](https://github.com/NixOS/nixpkgs/commit/9f0f06ac8beb8852d7ab3c5732e1c008c312f38d) freeradius: make debug logging optional
* [`3ad85969`](https://github.com/NixOS/nixpkgs/commit/3ad8596931f96ea6cb77f90efad50f45b4899a97) Revert "riot-desktop: wrap with wrapGAppsHook"
* [`22b5a32f`](https://github.com/NixOS/nixpkgs/commit/22b5a32fad48dea2100053fdbbd64d941377ac23) electron: fix wrapGAppsHook usage
* [`8aa17dea`](https://github.com/NixOS/nixpkgs/commit/8aa17dea0f181a61a16d6164cdd39b20bb21a531) modemmanager: 1.12.4 -> 1.12.6
* [`21750051`](https://github.com/NixOS/nixpkgs/commit/21750051b2686ade738d1eeb80c1955b0234aadd) modemmanager: 1.12.6 -> 1.12.8
* [`ecfd73db`](https://github.com/NixOS/nixpkgs/commit/ecfd73db44a9337ffbe4816c82c953399a19ca4f) acme: share accounts between certificates
* [`89b864de`](https://github.com/NixOS/nixpkgs/commit/89b864de6420c99837c8cebc9639b959c6d7cee6) ethminer: mark as broken
* [`3add50e5`](https://github.com/NixOS/nixpkgs/commit/3add50e56db4a618c19889652e92ef79b3e631bb) luminance-hdr: use Qt5's mkDerivation
* [`897182cd`](https://github.com/NixOS/nixpkgs/commit/897182cdaf580f238a5660aef7d70827480aa7a2) nixosTests.networking.virtual: fix with networkd
* [`8b40e890`](https://github.com/NixOS/nixpkgs/commit/8b40e8907be0b69bd541c4105cfaff3d05a93910) dysnomia: 0.9 -> 0.9.1
* [`6fd93c33`](https://github.com/NixOS/nixpkgs/commit/6fd93c338992d9812d345110e53abb8d8ea95660) nixos/dysnomia: fix documentRoot property
* [`7f9c1d0e`](https://github.com/NixOS/nixpkgs/commit/7f9c1d0ec3c4d2e164a32f0818be23a6c4eec23d) nixos/libinput: refer to libinput manual
* [`e393449b`](https://github.com/NixOS/nixpkgs/commit/e393449b43452b65ca7068c510253d0e1fa64d2b) airsonic: enable nginx.recommendedProxySettings with virtualHost
* [`946287b3`](https://github.com/NixOS/nixpkgs/commit/946287b3197f3adb7e72a6c8ad5b2b48abc113ad) mkl: 2020.0.166 -> 2020.1.217
* [`67e45efa`](https://github.com/NixOS/nixpkgs/commit/67e45efa3a48d87b00eb0b4c154f692e5887d35b) nix-zsh-completions: 0.4.3 -> 0.4.4 (NixOS/nixpkgs#85267)
* [`a438aed5`](https://github.com/NixOS/nixpkgs/commit/a438aed5a6ceda6beaa998af1c67a38f4b4c3156) tig: fix tig-completion's dependency on __git_complete
* [`8c3b765b`](https://github.com/NixOS/nixpkgs/commit/8c3b765bc6328d3c6053c392375fcca39ac1f23d) cargo-make: 0.30.4 -> 0.30.5
* [`6ca86a05`](https://github.com/NixOS/nixpkgs/commit/6ca86a05fb726f9a89f7b585d2ceacd5f77ebfce) ping: use vala_0_40
* [`142afb89`](https://github.com/NixOS/nixpkgs/commit/142afb8942ee1197a07aeb40015e1152452c4db4) nasc: fix build
* [`d219b7b5`](https://github.com/NixOS/nixpkgs/commit/d219b7b59f97ed39289a598fd34b63ac5e848883) chromedriver: 78.0.3904.70 -> 81.0.4044.69
* [`9c11bd93`](https://github.com/NixOS/nixpkgs/commit/9c11bd93183c8261c77efa60f3389416cda19a29) ephemeral: 6.3.0 -> 6.3.1
* [`a5ad7267`](https://github.com/NixOS/nixpkgs/commit/a5ad72673441c0d3bbdb548cf93661f2223f2ec2) agenda: 1.0.12 -> 1.1.0
* [`2c0f6ef1`](https://github.com/NixOS/nixpkgs/commit/2c0f6ef15fd0b21898f3b999ea3cd16136c9a496) monitor: 0.6.2 -> 0.7.1
* [`a37adb33`](https://github.com/NixOS/nixpkgs/commit/a37adb336786c8fd0ce86e2f067d721496949a84) monitor: add note how to use indicator.
* [`17f92998`](https://github.com/NixOS/nixpkgs/commit/17f92998ad6610093d4324ceb7062a626cf4ffb4) ephemeral: 6.3.1 -> 6.3.3
* [`e6b82df1`](https://github.com/NixOS/nixpkgs/commit/e6b82df11dbb3c351789a8620762b6fc6d02fd4c) pantheon.elementary-videos: 2.7.0 -> 2.7.1
* [`931c4db6`](https://github.com/NixOS/nixpkgs/commit/931c4db67ad116c0a02e9272ac09db3d3e7a47dd) pantheon.pantheon-agent-geoclue2: 1.0.3 -> 1.0.4
* [`92d43c92`](https://github.com/NixOS/nixpkgs/commit/92d43c9279fb00fbfde4214b23240927b5928ec8) multimc: 0.6.7 -> 0.6.11
* [`0f920b05`](https://github.com/NixOS/nixpkgs/commit/0f920b05cbcdb8c0f3c5c4a8ea29f1f0065c7033) g2o: fix log limit exceeded error in Hydra
