### PR TITLE
niv niv: update f73bf8d5 -> dd17834c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "f73bf8d584148677b01859677a63191c31911eae",
-        "sha256": "0jlmrx633jvqrqlyhlzpvdrnim128gc81q5psz2lpp2af8p8q9qs",
+        "rev": "dd17834c49aa765c222d77b6d22f8de7af03a3c1",
+        "sha256": "1g2z8mq4lid1vy61rhyib9z2xhy096z28jbjxpx6xf3cf0kvjjc1",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/f73bf8d584148677b01859677a63191c31911eae.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/dd17834c49aa765c222d77b6d22f8de7af03a3c1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for niv:
Commits: [nmattia/niv@f73bf8d5...dd17834c](https://github.com/nmattia/niv/compare/f73bf8d584148677b01859677a63191c31911eae...dd17834c49aa765c222d77b6d22f8de7af03a3c1)

* [`2818ce64`](https://github.com/nmattia/niv/commit/2818ce648c7e4468e8b70f46df2854e1cb34b98e) Fix macOS build
* [`66e79bc3`](https://github.com/nmattia/niv/commit/66e79bc38a8a2571caa767a1578b50521d8ce13d) Define Cachix signing key in action
* [`0fe342db`](https://github.com/nmattia/niv/commit/0fe342db13a665308309e18f96a7e2bb7a7eea16) Update nix GitHub action
* [`dd17834c`](https://github.com/nmattia/niv/commit/dd17834c49aa765c222d77b6d22f8de7af03a3c1) Add FAQ section to README
