### PR TITLE
niv nixpkgs: update 1fb95d95 -> 925ae0de

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1fb95d956cc7f3f29366cb275f6254fd1e278bc5",
-        "sha256": "0pf3fqkm94f5j6vxsm4zbyq293rb0cpxqwdxzhp6agv6w5j5fmki",
+        "rev": "925ae0dee63cf2c59533a6258340812e5643428a",
+        "sha256": "1g3kkwyma23lkszdvgb4dn91g35b082k55ys8azc7j4s6vxpzmaw",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/1fb95d956cc7f3f29366cb275f6254fd1e278bc5.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/925ae0dee63cf2c59533a6258340812e5643428a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-static": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Commits: [NixOS/nixpkgs@1fb95d95...925ae0de](https://github.com/NixOS/nixpkgs/compare/1fb95d956cc7f3f29366cb275f6254fd1e278bc5...925ae0dee63cf2c59533a6258340812e5643428a)

* [`7fe5ff27`](https://github.com/NixOS/nixpkgs/commit/7fe5ff27a3389575c560260cd74bbc858d0c7226) nixpkgs-review: 2.3.1 -> 2.4.0
* [`c86eb53a`](https://github.com/NixOS/nixpkgs/commit/c86eb53a88af80a93246d63466cd6a95f7d800bb) libfishsound at 1.0.0
* [`925ae0de`](https://github.com/NixOS/nixpkgs/commit/925ae0dee63cf2c59533a6258340812e5643428a) sonic-visualiser: 2.4.1 -> 4.0.1
