### PR TITLE
niv nixpkgs-static: update dbce18f4 -> 38215029

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nh2",
         "repo": "static-haskell-nix",
-        "rev": "dbce18f4808d27f6a51ce31585078b49c86bd2b5",
-        "sha256": "084hxnrywsgb73zr41argdkbhkxzm1rqn058pv1l4cp9g1gjr2rr",
+        "rev": "382150290ba43b6eb41981c1ab3b32aa31798140",
+        "sha256": "0zsyplzf1k235rl26irm27y5ljd8ciayw80q575msxa69a9y2nvd",
         "type": "tarball",
-        "url": "https://github.com/nh2/static-haskell-nix/archive/dbce18f4808d27f6a51ce31585078b49c86bd2b5.tar.gz",
+        "url": "https://github.com/nh2/static-haskell-nix/archive/382150290ba43b6eb41981c1ab3b32aa31798140.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
## Changelog for nixpkgs-static:
Commits: [nh2/static-haskell-nix@dbce18f4...38215029](https://github.com/nh2/static-haskell-nix/compare/dbce18f4808d27f6a51ce31585078b49c86bd2b5...382150290ba43b6eb41981c1ab3b32aa31798140)

* [`38215029`](https://github.com/nh2/static-haskell-nix/commit/382150290ba43b6eb41981c1ab3b32aa31798140) README: Say where nix.conf is
