### PR TITLE
niv nixpkgs: update 925ae0de -> 504f993d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "925ae0dee63cf2c59533a6258340812e5643428a",
-        "sha256": "1g3kkwyma23lkszdvgb4dn91g35b082k55ys8azc7j4s6vxpzmaw",
+        "rev": "504f993df9a5ca63317fe9c859df19daad30aa14",
+        "sha256": "19innk4v45xq62q6n5h0alhfbb3v7yxpdd1r7sglgjn8sr3ylwmn",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/925ae0dee63cf2c59533a6258340812e5643428a.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/504f993df9a5ca63317fe9c859df19daad30aa14.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-static": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Commits: [NixOS/nixpkgs@925ae0de...504f993d](https://github.com/NixOS/nixpkgs/compare/925ae0dee63cf2c59533a6258340812e5643428a...504f993df9a5ca63317fe9c859df19daad30aa14)

* [`3cb2ca50`](https://github.com/NixOS/nixpkgs/commit/3cb2ca50e9e7cf945146eb09e3e521bed9403a14) pantheon.elementary-dock: fix double includedir in .pc
* [`4bada3ac`](https://github.com/NixOS/nixpkgs/commit/4bada3ac11dddd4d0e43fb9526dd1ed04ea8d559) pantheon.appcenter: 3.4.0 -> 3.4.2
* [`95bf5a41`](https://github.com/NixOS/nixpkgs/commit/95bf5a41c5fe57233cdc6a0c46ea7844257042e0) hovercraft: 2.6 -> 2.7
* [`f59f6181`](https://github.com/NixOS/nixpkgs/commit/f59f61817cf1ea7c2b5acb416d6e769d09977278) hovercraft: remove broken meta tag
* [`aa8ccad1`](https://github.com/NixOS/nixpkgs/commit/aa8ccad1b1bc320913f81e0bebdfebc2f3019459) adns: 1.5.1 -> 1.5.2
* [`eb6ac6ab`](https://github.com/NixOS/nixpkgs/commit/eb6ac6ab6836247463e02fc129fe3f278bcefead) nixos/fontconfig: Fix compatibility with unstable apps
* [`835392d6`](https://github.com/NixOS/nixpkgs/commit/835392d69dd10ae9a9b99f1eca0e73f4a9de21d7) linux: 5.4.62 -> 5.4.63
* [`d397c6ac`](https://github.com/NixOS/nixpkgs/commit/d397c6ac165445443fcf4b65885829c2f188ae87) palemoon: Add libpulseaudio to wrapper
* [`26a05bf3`](https://github.com/NixOS/nixpkgs/commit/26a05bf3da5c8d510b698330130ca4dc46fb3ba1) linuxPackages.wireguard: 1.0.20200729 -> 1.0.20200908
* [`43a6e63b`](https://github.com/NixOS/nixpkgs/commit/43a6e63b317fbaf425c53aff9f8a4c7c0f40ad9b) nodePackages.node-red: fix build
* [`167d2db8`](https://github.com/NixOS/nixpkgs/commit/167d2db830b7b62bece2e5f4ef1ff994175301b7) flashplayer: 32.0.0.414 -> 32.0.0.433
* [`6e9eedf2`](https://github.com/NixOS/nixpkgs/commit/6e9eedf268c9ac02f1887a1d76389a5dca6e8ade) terraform_0_12: add patch with fix for macos mojave when built with go 1.14
* [`57a83122`](https://github.com/NixOS/nixpkgs/commit/57a83122d927015efaa242b33c76cdf3c0df8540) tbb: fix library install name on macOS
* [`72614e19`](https://github.com/NixOS/nixpkgs/commit/72614e199af7a80df8cc2ff60f33519e5889be51) go: 1.14.4 -> 1.14.5
* [`7817ddd0`](https://github.com/NixOS/nixpkgs/commit/7817ddd0d721e6fef603f289dd347befc1da49ee) go: 1.14.5 -> 1.14.6
* [`3b601bb9`](https://github.com/NixOS/nixpkgs/commit/3b601bb991f2209d9c9ad915def53f4c8d747680) go_1_13: 1.13.12 -> 1.13.13
* [`b2cb4655`](https://github.com/NixOS/nixpkgs/commit/b2cb46557bf6e5b38c0cd9e683ffc6f89a0fe4a1) go_1_13: 1.13.13 -> 1.13.14
* [`fa7a3c1c`](https://github.com/NixOS/nixpkgs/commit/fa7a3c1ca89dca651000525d5c6c2bb900eb40fe) go_1_13: 1.13.14 -> 1.13.15
* [`0b8db6f7`](https://github.com/NixOS/nixpkgs/commit/0b8db6f7171e09857338acd3fec24e4996d5e86c) go: 1.14.6 -> 1.14.7
* [`d3f3208a`](https://github.com/NixOS/nixpkgs/commit/d3f3208a6ebfe737bed28230d81d8c5a5ee038c2) go_1_14: 1.14.7 -> 1.14.8
* [`ac43451a`](https://github.com/NixOS/nixpkgs/commit/ac43451abe7e82aaa596ab8b87d50e7178fca8b4) linux: 4.14.196 -> 4.14.197
* [`dd1ddd1d`](https://github.com/NixOS/nixpkgs/commit/dd1ddd1d69e83ca0b49be8c3ce6506c0702093e2) linux: 4.19.143 -> 4.19.144
* [`6a000982`](https://github.com/NixOS/nixpkgs/commit/6a0009824e65dbb8ab7dfcf1c665a815d0bc4708) linux: 5.4.63 -> 5.4.64
* [`73c6b9a8`](https://github.com/NixOS/nixpkgs/commit/73c6b9a88d2dc75de8261266273435b3e02b31ad) jenkins: 2.235.3 -> 2.235.5
* [`27561494`](https://github.com/NixOS/nixpkgs/commit/27561494641962d0e3c38966c79acab2632021ef) jenkins: 2.235.5 -> 2.249.1
* [`e6bc03be`](https://github.com/NixOS/nixpkgs/commit/e6bc03bea05914de1c14812ccebdd914bf106c0d) systemd-confinement: handle ExecStarts etc being lists
* [`53b01bdf`](https://github.com/NixOS/nixpkgs/commit/53b01bdfe985247169343540596020e8bc56e2d3) discord: 0.0.11 -> 0.0.12
* [`67985ae1`](https://github.com/NixOS/nixpkgs/commit/67985ae151062736473e99f057c69639ec36124b) discord-ptb: 0.0.21 -> 0.0.22
* [`c291195e`](https://github.com/NixOS/nixpkgs/commit/c291195eedf00aeede00c6e94e95275ca4f9ad9d) discord-canary: 0.0.111 -> 0.0.112
* [`849ef3ba`](https://github.com/NixOS/nixpkgs/commit/849ef3ba9b96db4c808f0044798871f0e381549e) signal-desktop: 1.35.1 -> 1.36.1
* [`4a4c9221`](https://github.com/NixOS/nixpkgs/commit/4a4c92212d03b8c062c614d6dd375ab04b0ead59) prosody: 0.11.5 -> 0.11.6
* [`fac425cc`](https://github.com/NixOS/nixpkgs/commit/fac425ccecd4748de51f115ba69701bd6e9e1ae9) nixos/dmidecode: added recommended patches
* [`4ea53630`](https://github.com/NixOS/nixpkgs/commit/4ea5363034260c804e3b5a133799abd6bd667794) traefik: 1.17.21 -> 1.17.26
* [`9103fba5`](https://github.com/NixOS/nixpkgs/commit/9103fba5a026ade984844845ee60265e0feec969) palemoon: 28.12.0 -> 28.13.0
* [`10ecc023`](https://github.com/NixOS/nixpkgs/commit/10ecc023a9a9368b7406c1e0b9bfd289dd637ff0) youtube-dl: 2020.09.06 -> 2020.09.14
* [`732684b7`](https://github.com/NixOS/nixpkgs/commit/732684b720f829056dcb62380c2c17e4d3ebd947) top-level: fix nix-shell eval w/nixUnstable
* [`fb8e820b`](https://github.com/NixOS/nixpkgs/commit/fb8e820bf8da158e64a494a18e4b7cb97c3e7be8) thunderbird: 78.2.1 -> 78.2.2
* [`c33f2cae`](https://github.com/NixOS/nixpkgs/commit/c33f2caedfae52fef757419cd5afef5ae8e1b8fe) thunderbird-bin: 78.2.1 -> 78.2.2
* [`db828516`](https://github.com/NixOS/nixpkgs/commit/db8285166ae1c62faea31015ac9f3f2c731c206e) linux: 4.14.197 -> 4.14.198
* [`947d26d3`](https://github.com/NixOS/nixpkgs/commit/947d26d343e3769aaee92c4e5d41989d8548139b) linux: 4.19.144 -> 4.19.145
* [`96d3c3f3`](https://github.com/NixOS/nixpkgs/commit/96d3c3f316d1ae4e62f35990533aad1d721e5254) linux: 4.4.235 -> 4.4.236
* [`7097e945`](https://github.com/NixOS/nixpkgs/commit/7097e94511e27aa935d191900087acb82437f705) linux: 4.9.235 -> 4.9.236
* [`a9f0ffa0`](https://github.com/NixOS/nixpkgs/commit/a9f0ffa06f2de24f12e4a40a2c778549f150d039) linux: 5.4.64 -> 5.4.65
* [`13d38bfb`](https://github.com/NixOS/nixpkgs/commit/13d38bfb2667fef377ace320313db07aac267165) pythonPackages.pyscard: Fix build on Darwin
* [`d2409578`](https://github.com/NixOS/nixpkgs/commit/d2409578c570172769081205bd8751081a4d4acc) element-web: 1.7.5 -> 1.7.7
* [`8a6e7487`](https://github.com/NixOS/nixpkgs/commit/8a6e7487fb49a21edfa7abe9b6a054d71187698d) element-desktop: 1.7.5 -> 1.7.7
* [`732163c1`](https://github.com/NixOS/nixpkgs/commit/732163c10f58ec5260e8efbe62507bba08213b6a) matrix-synapse: 1.19.1 -> 1.19.2
* [`eb92e887`](https://github.com/NixOS/nixpkgs/commit/eb92e8876d097963dc9917b09ede79a472bd8ee4) linux: 4.19.145 -> 4.19.146
* [`faf5bdea`](https://github.com/NixOS/nixpkgs/commit/faf5bdea5d9f0f9de26deaa7e864cdcd3b15b4e8) linux: 5.4.65 -> 5.4.66
* [`985047d3`](https://github.com/NixOS/nixpkgs/commit/985047d3c9fb16bb05bc8cde7d2a1a703f670eae) texlive: fix arara
* [`2b803260`](https://github.com/NixOS/nixpkgs/commit/2b803260a6e917a541a10cafee0f753ca5daf901) [cpan2nix] perlPackages.DBI: 1.642 -> 1.643 (for CVE-2020-14392, CVE-2020-14393)
* [`773ef5ae`](https://github.com/NixOS/nixpkgs/commit/773ef5ae78339db744b917c2b35d28812028bd8c) youtube-dl: 2020.09.14 -> 2020.09.20
* [`28651044`](https://github.com/NixOS/nixpkgs/commit/28651044ad724fc549e672366b3e9a1c3d151706) nextcloud17: 17.0.6 -> 17.0.9
* [`488bb6ad`](https://github.com/NixOS/nixpkgs/commit/488bb6ad2ae3661d092f39eca5e2bc85af0d85b8) nextcloud18: 18.0.7 -> 18.0.9
* [`6f12279a`](https://github.com/NixOS/nixpkgs/commit/6f12279ae3515f977a9961ff378fa3f3ac528d25) nextcloud19: 19.0.1 -> 19.0.3
* [`6b11dbe9`](https://github.com/NixOS/nixpkgs/commit/6b11dbe9672a49dbe454a39644e429bf647faacb) matrix-synapse: 1.19.2 -> 1.19.3
* [`5289f227`](https://github.com/NixOS/nixpkgs/commit/5289f227c2501b114ea5184ccbeb57ba2544a496) fzf: 0.20.0 -> 0.21.0
* [`f3e31990`](https://github.com/NixOS/nixpkgs/commit/f3e31990a9ffc3b4169c7f9442ad5b2d2a7cbec5) fzf: 0.21.0 -> 0.21.0-1
* [`a0b222cc`](https://github.com/NixOS/nixpkgs/commit/a0b222ccf3cfbada08003f17e8f990f6f9b4cbcb) fzf: 0.21.0-1 -> 0.21.1
* [`21d8e70a`](https://github.com/NixOS/nixpkgs/commit/21d8e70a69f704a6ab971b2d8265d40cc7bb69b1) fzf: 0.21.1 -> 0.22.0
* [`abf627cc`](https://github.com/NixOS/nixpkgs/commit/abf627cc15a46083da25d5566e6015f2546d62b3) thunderbird-78: fix NixOS/nixpkgs#97994: broken UI in 78.2.2
* [`683736a0`](https://github.com/NixOS/nixpkgs/commit/683736a0f2ba5432b2e7f5ede37fe1afa0952cbf) coturn: 4.5.1.2 -> 4.5.1.3
* [`68efe6db`](https://github.com/NixOS/nixpkgs/commit/68efe6dbf9285245e17f151cf79648a9db988302) python3Packages.Django: 2.2.14 -> 2.2.15
* [`6ec10fc7`](https://github.com/NixOS/nixpkgs/commit/6ec10fc77e56b9f848930f129833cfbbac736e4f) pythonPackages.django: 2.2.15 -> 2.2.16
* [`de0137d2`](https://github.com/NixOS/nixpkgs/commit/de0137d27a3a877837713eba899004c41e3a93c5) softmaker-office: remove /bin/ls intercept
* [`4b55b485`](https://github.com/NixOS/nixpkgs/commit/4b55b4853ac604236aed37963e882203cf358683) freeoffice: 976 -> 978
* [`f8271cb3`](https://github.com/NixOS/nixpkgs/commit/f8271cb3364bfce4a6474a5893c2ce81d88cdeb5) softmaker-office: 976 -> 978
* [`ad76375b`](https://github.com/NixOS/nixpkgs/commit/ad76375bfc7644e229bebe0a9df8854e2041d867) gnutls: 3.6.14 -> 3.6.15
* [`710d9682`](https://github.com/NixOS/nixpkgs/commit/710d9682479806104666d6e87254770438620c25) chromiumDev: 86.0.4238.0 -> 86.0.4240.8
* [`00740317`](https://github.com/NixOS/nixpkgs/commit/00740317ecb53f941d76edd18878a9cb04f608c9) chromium: replace update.nix with Python impl
* [`bc8cb021`](https://github.com/NixOS/nixpkgs/commit/bc8cb021fbf4c073d17c3232a20b2aecfa76be4d) chromiumBeta: 85.0.4183.83 -> 86.0.4240.22
* [`79b88efc`](https://github.com/NixOS/nixpkgs/commit/79b88efc582a784dd2189744925c45d0321cb0c4) chromium: Unblock nixos-unstable by using the correct argument to fetchurl
* [`0cd31b9e`](https://github.com/NixOS/nixpkgs/commit/0cd31b9ec268d007b0a43c9a94494bb867ff39f5) chromium: Prefix $PATH with xdg_utils (NixOS/nixpkgs#96922)
* [`8504341e`](https://github.com/NixOS/nixpkgs/commit/8504341edae9cd9edecbb3cebe2e8c2774ca272d) chromium: 85.0.4183.83 -> 85.0.4183.102
* [`f535718a`](https://github.com/NixOS/nixpkgs/commit/f535718ae68c52ac358c1044f5bfe544e7d3e4c2) chromium: update.py: Keep the channel order consistent
* [`40b58a1f`](https://github.com/NixOS/nixpkgs/commit/40b58a1fca09a5165eb0a61eceaaa5fdd34bac27) chromiumDev: M86 -> M87
* [`39d5f7e0`](https://github.com/NixOS/nixpkgs/commit/39d5f7e0f150f7098d9c49664c7311ce94b08002) chromium: 85.0.4183.102 -> 85.0.4183.121
* [`ce758e6d`](https://github.com/NixOS/nixpkgs/commit/ce758e6daaf4cd672019ec9c01a423db1e61100d) linux: 4.14.198 -> 4.14.199
* [`70c89131`](https://github.com/NixOS/nixpkgs/commit/70c8913197734701e7ac45c3d2d448dd9af20700) linux: 4.19.146 -> 4.19.147
* [`f1773ffb`](https://github.com/NixOS/nixpkgs/commit/f1773ffb3c02c54d22bba3c2b0e2afbf5dee1980) linux: 4.4.236 -> 4.4.237
* [`9ae9a70c`](https://github.com/NixOS/nixpkgs/commit/9ae9a70c15eb3fb189df479408413e8b1fbf9276) linux: 4.9.236 -> 4.9.237
* [`0bc6da3a`](https://github.com/NixOS/nixpkgs/commit/0bc6da3ab075f3ca35b83b6a2069a389bd769c1e) linux: 5.4.66 -> 5.4.67
* [`754d7bbf`](https://github.com/NixOS/nixpkgs/commit/754d7bbfd789d06c58c7eec44765ea5fadd5b6f5) doc: rename guide to 'Nixpkgs Manual'
* [`75c850d4`](https://github.com/NixOS/nixpkgs/commit/75c850d4f35e4144c93a08a52e8e363b43ec4004) firefox-esr: 78.2.0esr -> 78.3.0esr
* [`3bbe4c8e`](https://github.com/NixOS/nixpkgs/commit/3bbe4c8e4fecbb4ba62f95b1303ec55e67e1bae4) firefox-bin: 79.0 -> 80.0 (NixOS/nixpkgs#96279)
* [`9703bb23`](https://github.com/NixOS/nixpkgs/commit/9703bb2340325930ca3cfe16b2281071dc75d921) firefox-bin: 80.0 -> 80.0.1
* [`9515a375`](https://github.com/NixOS/nixpkgs/commit/9515a3751f4c25d1448c34c3d5a54c8fff0838ef) firefox-bin: 80.0.1 -> 81.0
* [`c483a726`](https://github.com/NixOS/nixpkgs/commit/c483a72642203f951ad7a5865180d37e80fdf3ce) tor-browser-bundle-bin: 9.5.4 -> 10.0
* [`a4915764`](https://github.com/NixOS/nixpkgs/commit/a4915764eccd66e588b5d9a942b114411e18bfd1) signal-desktop: 1.36.1 -> 1.36.2
* [`a33f7dc0`](https://github.com/NixOS/nixpkgs/commit/a33f7dc09151f0cb324987d3479ed25f3583f709) nss_latest: 3.55 -> 3.56
* [`147b3035`](https://github.com/NixOS/nixpkgs/commit/147b303509c7757bfbd9e5cf70bd2349255d01f2) firefox: 80.0 -> 80.0.1
* [`fd6a66f8`](https://github.com/NixOS/nixpkgs/commit/fd6a66f882a6e718f58bfccf03b041da8bb71e88) firefox: 80.0.1 -> 81.0
* [`93c68eaf`](https://github.com/NixOS/nixpkgs/commit/93c68eaf4f3b927dee31accc55a9c3c3c5cc94ca) firefox-esr-68: mark as insecure
* [`9f5ba92b`](https://github.com/NixOS/nixpkgs/commit/9f5ba92b945d38f624513c5ae81c0181595cb901) Merge NixOS/nixpkgs#98684: brotli: fix patch URL
* [`bef364c8`](https://github.com/NixOS/nixpkgs/commit/bef364c849b6a51a274b3ceb55abe6bb8a8343d3) signal-desktop: 1.36.2 -> 1.36.3
* [`5662a6fa`](https://github.com/NixOS/nixpkgs/commit/5662a6faae6b9611fc93d2426b8484f3e495f8a3) llvm_11: Copy all files from llvmPackages_10
* [`dac4a48b`](https://github.com/NixOS/nixpkgs/commit/dac4a48b4565697ae80c39a0d98ca6cdb480c4c3) llvm_11: init at 11.0.0rc1
* [`3768fdea`](https://github.com/NixOS/nixpkgs/commit/3768fdea92b310e118d595813e7877e098ec3bb6) llvm_11: 11.0.0rc1 -> 11.0.0rc2
* [`bed75af2`](https://github.com/NixOS/nixpkgs/commit/bed75af2bb1bcdf7413e027172f7f30cec40fe4a) chromiumDev: Drop nix_plugin_paths_68.patch
* [`ef889f43`](https://github.com/NixOS/nixpkgs/commit/ef889f43d9683cc40dbd87f77a8c67e445c5ef99) chromiumDev: Drop the optional VA-API patches
* [`f6a84a22`](https://github.com/NixOS/nixpkgs/commit/f6a84a223aa6ddf0af9f29bf8c59c51b279bfcb7) chromiumDev: Fix "patchShebangs ."
* [`fdb4b8f9`](https://github.com/NixOS/nixpkgs/commit/fdb4b8f9acc6ec3bdb8972ab3600d72fe5696c2b) chromiumBeta: Fix the build by using LLVM 11
* [`360e2af4`](https://github.com/NixOS/nixpkgs/commit/360e2af4f876e2580de12d477a6167ed756ab65e) Merge NixOS/nixpkgs#98628: thunderbird*: 78.2.2 -> 78.3.1 (security)
* [`ad246fb8`](https://github.com/NixOS/nixpkgs/commit/ad246fb8745827a02fbe0972c2b09c0051172911) nixos/security/wrapper: ensure the tmpfs is not world writeable
* [`c9fb1778`](https://github.com/NixOS/nixpkgs/commit/c9fb1778ffb6c264a1d2d2ae502cb17b6ce87945) linux: 4.19.147 -> 4.19.148
* [`f646148b`](https://github.com/NixOS/nixpkgs/commit/f646148ba713e85ea2539fd3069ca31d93dd4774) linux: 5.4.67 -> 5.4.68
* [`6b80a3d3`](https://github.com/NixOS/nixpkgs/commit/6b80a3d38d93a0cf8d23a2ea9777cb8b89a7484e) roundcube: 1.4.8 -> 1.4.9
* [`5accfcfa`](https://github.com/NixOS/nixpkgs/commit/5accfcfa779d4fd05ce4b367f55b491d19efbe59) graylog: 3.3.4 -> 3.3.6
* [`b8a2127b`](https://github.com/NixOS/nixpkgs/commit/b8a2127b5bd5cc4b9abb8498c8dbf0bd970ae9f9) Merge pull request NixOS/nixpkgs#99270 from NeQuissimus/linux_5_4_69
* [`6c822ca8`](https://github.com/NixOS/nixpkgs/commit/6c822ca88c1795bb689997f32cf52535f9dcc472) Merge pull request NixOS/nixpkgs#99269 from NeQuissimus/linux_4_4_238
* [`61262952`](https://github.com/NixOS/nixpkgs/commit/612629526f446a0a8137b4ae09e604922db7091a) Merge pull request NixOS/nixpkgs#99267 from NeQuissimus/linux_4_19_149
* [`e6810a0d`](https://github.com/NixOS/nixpkgs/commit/e6810a0dfb40c2ada03f0c51b93fa331288ccdbc) Merge pull request NixOS/nixpkgs#99266 from NeQuissimus/linux_4_14_200
* [`151e1aa0`](https://github.com/NixOS/nixpkgs/commit/151e1aa066b9ee20b0c2dd7f10e359f246f56d69) element-desktop: 1.7.7 -> 1.7.8
* [`b7b36a2f`](https://github.com/NixOS/nixpkgs/commit/b7b36a2fbe8d59133daf8fc1a4bbda6e942e7fc5) element-web: 1.7.7 -> 1.7.8
* [`b2d463f0`](https://github.com/NixOS/nixpkgs/commit/b2d463f0e3ff28ce028e192b1cc32a5b6eb7f42e) linux: 4.9.237 -> 4.9.238
* [`960c3fcd`](https://github.com/NixOS/nixpkgs/commit/960c3fcda22e7ea1f51cf9f27c5e19c0082a10f5) php74: 7.4.8 -> 7.4.11
* [`8c9449ef`](https://github.com/NixOS/nixpkgs/commit/8c9449ef59f15041420251020c71abe383c8f95b) php73: 7.3.20 -> 7.3.23
* [`760c6ec7`](https://github.com/NixOS/nixpkgs/commit/760c6ec78cd6d8d658266ac28434a3b04a9e4cbb) matrix-synapse: 1.19.3 -> 1.20.1
* [`adc7650b`](https://github.com/NixOS/nixpkgs/commit/adc7650bf25d3efec8e82088f36f3c1ef7f96d0f) nixos/nextcloud: fix `nginx`-config for Nextcloud 19 and older
* [`f8d4aa5c`](https://github.com/NixOS/nixpkgs/commit/f8d4aa5c1cbf53a46293df6b542610f961194246) python.pkgs.fontforge: disable with Python 2
* [`d6f46d2a`](https://github.com/NixOS/nixpkgs/commit/d6f46d2a91b77d46abcbcc74861ff311d9df9741) monoid: 2016-07-21 -> 2018-06-03
* [`0872da10`](https://github.com/NixOS/nixpkgs/commit/0872da10808ee370e64f747ab9fef38755c05549) Revert "top-level: fix nix-shell eval w/nixUnstable"
* [`b2a04c5f`](https://github.com/NixOS/nixpkgs/commit/b2a04c5f280928aa4e577fe006ad8a7c7f539fc1) top-level: ignore unexpected args
* [`06ce0d95`](https://github.com/NixOS/nixpkgs/commit/06ce0d954b659c60221ee1dda5270a083e52e681) thunderbird*: switch default: 68 -> 78
* [`0e5d4c28`](https://github.com/NixOS/nixpkgs/commit/0e5d4c28abba28aa7c8718efb9b94b0f370507b5) wire-desktop: linux 3.18.2925 -> 3.20.2934
* [`09548564`](https://github.com/NixOS/nixpkgs/commit/095485644d4b3173b005cc0c224549ff620ba5e3) wire-desktop: mac 3.18.3728 -> 3.20.3912
* [`bb7dc854`](https://github.com/NixOS/nixpkgs/commit/bb7dc854f51a36792b65d62703db7a93e0b248c2) linux: 4.19.149 -> 4.19.150
* [`067d8e6c`](https://github.com/NixOS/nixpkgs/commit/067d8e6c9f4ad3df62d4c9359865747aedea8853) linux: 5.4.69 -> 5.4.70
* [`0d474ee1`](https://github.com/NixOS/nixpkgs/commit/0d474ee1aede39c1fa5dc82a6cc0d531cb1cd741) nixos/nextcloud: fix nginx config to allow copy/move-operations again
* [`08d42992`](https://github.com/NixOS/nixpkgs/commit/08d429920bcb2dba1d47c93e5ed30d0f92838c89) knot-dns: 2.9.6 -> 2.9.7
* [`d74573d8`](https://github.com/NixOS/nixpkgs/commit/d74573d8ae6f02ef0ac1299c862d1b762ba0aad1) nixos/display-managers: install sessionData.desktops
* [`4a39f290`](https://github.com/NixOS/nixpkgs/commit/4a39f290842b6e2347824989582e048535092325) chromium: 85.0.4183.121 -> 86.0.4240.75
* [`b89c2710`](https://github.com/NixOS/nixpkgs/commit/b89c2710b5da69338c370e3e157ecee17a5b2436) chromium: Fix and enable our ANGLE support
* [`208a8f86`](https://github.com/NixOS/nixpkgs/commit/208a8f867bb58bd199c3abff0ec6ffbe4c9cabab) chromium: Disable VA-API by default
* [`1637c072`](https://github.com/NixOS/nixpkgs/commit/1637c072752b0cb4c494414ade066656c89245b1) llvm_11: 11.0.0rc2 -> 11.0.0rc3
* [`fa304506`](https://github.com/NixOS/nixpkgs/commit/fa304506f34310594a9afab94cabecea6a914c83) llvm_11: 11.0.0rc3 -> 11.0.0rc5
* [`deebf775`](https://github.com/NixOS/nixpkgs/commit/deebf775f85a546bea70d962408f2867e04f01d9) palemoon: 28.13.0 -> 28.14.2
* [`2a27a95e`](https://github.com/NixOS/nixpkgs/commit/2a27a95edd6c0126f539960a2b32ee9c830869d9) thunderbird*-68: mark as insecure
* [`b206b2d7`](https://github.com/NixOS/nixpkgs/commit/b206b2d73744e0b19afcbda847e8cb6c95abe777) graylog: 3.3.6 -> 3.3.7
* [`b601cd5e`](https://github.com/NixOS/nixpkgs/commit/b601cd5e1d2f9e7294b6ef9fe547ba785db16a27) element-web: 1.7.8 -> 1.7.9
* [`53c37f9d`](https://github.com/NixOS/nixpkgs/commit/53c37f9d804a665609fcb11650bed835ecfe0bac) element-desktop: 1.7.8 -> 1.7.9
* [`5854ffb0`](https://github.com/NixOS/nixpkgs/commit/5854ffb0364de475d52f057aaf02b767f4c22a13) graylog: 3.3.7 -> 3.3.8
* [`d3784204`](https://github.com/NixOS/nixpkgs/commit/d3784204ba1a6bbb0c0ebf89b706bda50c113112) podman: Add patch for CVE-2020-14370
* [`62d98640`](https://github.com/NixOS/nixpkgs/commit/62d986406e47910950341afb1e285996a4d09e25) pdns-recursor: 4.2.2 -> 4.2.5
* [`8e5088cd`](https://github.com/NixOS/nixpkgs/commit/8e5088cd2d58e18cc221f6eba9b40e34e5e4e958) matrix-synapse: 1.20.1 -> 1.21.0
* [`3a10a004`](https://github.com/NixOS/nixpkgs/commit/3a10a004bb5802d5f23c58886722e4239705e733) python37Packages.canonicaljson: 1.3.0 -> 1.4.0
* [`e1c3cfec`](https://github.com/NixOS/nixpkgs/commit/e1c3cfecb8632fe92b99def4d79ba0ef1cbe4886) firefox: 81.0 -> 81.0.2
* [`7c425771`](https://github.com/NixOS/nixpkgs/commit/7c425771555524cb69e4c863b4ed0541b764a473) firefox-bin: 81.0 -> 81.0.2
* [`9ce60fdc`](https://github.com/NixOS/nixpkgs/commit/9ce60fdcf2d903ceadd6198dae4789bf2605f63a) firefox-esr: 78.3.0esr -> 78.3.1esr
* [`51e920df`](https://github.com/NixOS/nixpkgs/commit/51e920df6dffc69d4049f1594d0a3b1441ffe47c) flashplayer: 32.0.0.433 -> 32.0.0.445
* [`65153e9f`](https://github.com/NixOS/nixpkgs/commit/65153e9f1401602997a97dfc177a2f8280469310) thunderbird: 78.2.2 -> 78.3.2
* [`7def3b54`](https://github.com/NixOS/nixpkgs/commit/7def3b549e3e88f0390ed7ea974067d661e3f2af) thunderbird-bin: 78.2.2 -> 78.3.2
* [`f973d9f8`](https://github.com/NixOS/nixpkgs/commit/f973d9f8130c40294738d395914a70fb62449b8e) linux: 4.14.200 -> 4.14.201
* [`aecb627f`](https://github.com/NixOS/nixpkgs/commit/aecb627f897f44b568951b771a60d721a39f5d4b) linux: 4.19.150 -> 4.19.151
* [`33a72a3c`](https://github.com/NixOS/nixpkgs/commit/33a72a3ca69c2af0bcc9c8bac775f5ab17695414) linux: 4.4.238 -> 4.4.239
* [`6d16bb3c`](https://github.com/NixOS/nixpkgs/commit/6d16bb3c09ec159d1abeb6498a3d841c87c0324b) linux: 4.9.238 -> 4.9.239
* [`eabc3161`](https://github.com/NixOS/nixpkgs/commit/eabc31612eabea2573a09ce5bcacdad3bfccd264) linux: 5.4.70 -> 5.4.71
* [`8fa9a8aa`](https://github.com/NixOS/nixpkgs/commit/8fa9a8aa02298d738d552cc36af2e816cf03badb) Revert "nixos/display-managers: install sessionData.desktops"
* [`b1eaa2d6`](https://github.com/NixOS/nixpkgs/commit/b1eaa2d6d251ec594dde6243eb22c36f635ada52) nomachine-client: 6.11.2 -> 6.12.3
* [`47a0d2d4`](https://github.com/NixOS/nixpkgs/commit/47a0d2d414cc0003ed4b8d1bcf648e9327bfa54f) shotcut: disable upgrade prompt
* [`90813d6e`](https://github.com/NixOS/nixpkgs/commit/90813d6e12674c82bb554d515d082c7e7ef83c87) matrix-synapse: 1.21.0 -> 1.21.2
* [`8117e60b`](https://github.com/NixOS/nixpkgs/commit/8117e60bef42725ce20baf2eb139ef6b3e06d82f) linux: 4.14.201 -> 4.14.202
* [`2db182ab`](https://github.com/NixOS/nixpkgs/commit/2db182abc8acd862e241984422b43495080d3650) linux: 4.19.151 -> 4.19.152
* [`357b14cf`](https://github.com/NixOS/nixpkgs/commit/357b14cfe961741e2f253160ef891e12b287c3bf) linux: 4.4.239 -> 4.4.240
* [`9a9d5ac8`](https://github.com/NixOS/nixpkgs/commit/9a9d5ac83c05b0756c1f16cf3b2b62b268345505) linux: 4.9.239 -> 4.9.240
* [`f702aab2`](https://github.com/NixOS/nixpkgs/commit/f702aab2d9cae14c554a4fa873a0665f99554fc9) linux: 5.4.71 -> 5.4.72
* [`0056f627`](https://github.com/NixOS/nixpkgs/commit/0056f627a0203501c82a74a59c7553b158cc9642) Merge NixOS/nixpkgs#98415: wordnet: Fix darwin build
* [`7c2a362b`](https://github.com/NixOS/nixpkgs/commit/7c2a362b58a1c2ba72d24aa3869da3b1a91d39e1) Merge NixOS/nixpkgs#100808:  thunderbird*: 78.3.2 -> 78.3.3
* [`ed0d061c`](https://github.com/NixOS/nixpkgs/commit/ed0d061c19429820cc83fea779d2687c2e928d6c) php72: 7.2.32 -> 7.2.34
* [`16a3eb65`](https://github.com/NixOS/nixpkgs/commit/16a3eb65f52778dea26a0726be895948fda42025) nss_latest: 3.56 -> 3.57
* [`f20eefd5`](https://github.com/NixOS/nixpkgs/commit/f20eefd55e3876e504f7e6857e4b31aa88c419aa) firefox: 81.0.2 -> 82.0
* [`386af259`](https://github.com/NixOS/nixpkgs/commit/386af259cee85ca068c15cf3142538d5198b15b8) firefox: 78.3.1esr -> 78.4.0esr
* [`b94c22f7`](https://github.com/NixOS/nixpkgs/commit/b94c22f717243da29a7ae4f7501e7fcaf884dab0) opensc: patch for CVE-2020-26570, CVE-2020-26572
* [`3f8fd69d`](https://github.com/NixOS/nixpkgs/commit/3f8fd69df2fc517d8d774b501a20e8562f4d480b) freetype: 2.10.2 -> 2.10.4
* [`0b308486`](https://github.com/NixOS/nixpkgs/commit/0b30848632a8e18e47464ec23651b0492b4d44b9) element-web: 1.7.9 -> 1.7.10
* [`ba9579ac`](https://github.com/NixOS/nixpkgs/commit/ba9579acd85bf440f73307f55080076c36734888) element-desktop: 1.7.9 -> 1.7.10
* [`9641db65`](https://github.com/NixOS/nixpkgs/commit/9641db654f2e4cc482c080835243345a472644c5) Revert "freetype: 2.10.2 -> 2.10.4"
* [`f433ace3`](https://github.com/NixOS/nixpkgs/commit/f433ace3fd5c712fd3e6177c44d6173105f40971) chromiumBeta: M86 -> M87
* [`648d838d`](https://github.com/NixOS/nixpkgs/commit/648d838d3d3c87b2392e183a12c49f74e15641d9) chromiumDev: M87 -> M88
* [`b560967c`](https://github.com/NixOS/nixpkgs/commit/b560967c7e3740a9ba5671dc93ce85472bfe88aa) chromium: 86.0.4240.75 -> 86.0.4240.111
* [`afcf3532`](https://github.com/NixOS/nixpkgs/commit/afcf35320d8cdce3f569f611819c302c1b724609) freetype: patch CVE-2020-15999
* [`b7bcf5e2`](https://github.com/NixOS/nixpkgs/commit/b7bcf5e2477a9f10179d9c2ee89949c0e74284c4) test-driver.py: Fix deadlock when the log queue gets full
* [`124e931e`](https://github.com/NixOS/nixpkgs/commit/124e931ed064427e102b187a9ffb367bdf32bc38) brave: 1.11.97 -> 1.15.76
* [`90c27d8f`](https://github.com/NixOS/nixpkgs/commit/90c27d8f120223d18dacdf586a82b63ace92261b) mumble: 1.3.1 -> 1.3.3
* [`a26e92a6`](https://github.com/NixOS/nixpkgs/commit/a26e92a67d884db696792d25dcc44c466a1bc8b4) Merge NixOS/nixpkgs#101380: thunderbird*: 78.3.2 -> 78.4.0
* [`e350840f`](https://github.com/NixOS/nixpkgs/commit/e350840f0a94c0c7a26f8c17b3df8ab352498c48) arx-libertatis: remove old override
* [`7cfafd01`](https://github.com/NixOS/nixpkgs/commit/7cfafd014f88e154de2592e2c2a48aeacd740eb3) tor-browser-bundle-bin: 10.0 -> 10.0.2
* [`8148771b`](https://github.com/NixOS/nixpkgs/commit/8148771b1a9d8cd439b57e02f0bdafab76693a28) Merge NixOS/nixpkgs#101611: firefox-bin: 81.0.2 -> 82.0
* [`e2b58333`](https://github.com/NixOS/nixpkgs/commit/e2b583332ac12133e1dd48bf7edce4b2a9233e45) google-chrome-{beta,dev}: fix icons (NixOS/nixpkgs#95389)
* [`6b5f85a6`](https://github.com/NixOS/nixpkgs/commit/6b5f85a62c445c14ca344bbe0de66927b13e0c20) google-chrome: add libxkbcommon+wayland for ozone/wayland
* [`e58039a7`](https://github.com/NixOS/nixpkgs/commit/e58039a7500a8d02bcdb2f21f184519df3368ee2) snmp_exporter: 0.17.0 -> 0.18.0
* [`ae6f01d5`](https://github.com/NixOS/nixpkgs/commit/ae6f01d549f3a9f9c20a503fb4d07db9f98f696e) prometheus-snmp-exporter: 0.18.0 -> 0.19.0
* [`00f3a335`](https://github.com/NixOS/nixpkgs/commit/00f3a335e3bb46f0145f27a4f14a6d27fde634a9) element-web: 1.7.10 -> 1.7.12
* [`e4167460`](https://github.com/NixOS/nixpkgs/commit/e416746006435ab78f24a1c33dd258c8958650d0) element-desktop: 1.7.10 -> 1.7.12
* [`e39c1f4e`](https://github.com/NixOS/nixpkgs/commit/e39c1f4ef17d36ce04fb75bd36f2e62b44ce0028) matrix-synapse: 1.21.2 -> 1.22.0
* [`504f993d`](https://github.com/NixOS/nixpkgs/commit/504f993df9a5ca63317fe9c859df19daad30aa14) matrix-synapse: make dependency for `hiredis` optional
