### PR TITLE
niv nixpkgs: update 504f993d -> 030e2ce8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "504f993df9a5ca63317fe9c859df19daad30aa14",
-        "sha256": "19innk4v45xq62q6n5h0alhfbb3v7yxpdd1r7sglgjn8sr3ylwmn",
+        "rev": "030e2ce817c8e83824fb897843ff70a15c131b96",
+        "sha256": "110kgp4x5bx44rgw55ngyhayr4s19xwy19n6qw9g01hvhdisilwf",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/504f993df9a5ca63317fe9c859df19daad30aa14.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/030e2ce817c8e83824fb897843ff70a15c131b96.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-static": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: nixos-20.03
Commits: [NixOS/nixpkgs@504f993d...030e2ce8](https://github.com/NixOS/nixpkgs/compare/504f993df9a5ca63317fe9c859df19daad30aa14...030e2ce817c8e83824fb897843ff70a15c131b96)

* [`fd702775`](https://github.com/NixOS/nixpkgs/commit/fd702775c02e73290475ee37a7e477b5d5534033) solr: 8.4.1 -> 8.5.0
* [`dc6333cf`](https://github.com/NixOS/nixpkgs/commit/dc6333cfa6d610531edd17ab5d985c8da06e47af) solr: 8.5.0 -> 8.5.1
* [`7a4bae9c`](https://github.com/NixOS/nixpkgs/commit/7a4bae9c2ffbc64a4e2b9536cca10bce609257b4) solr: 8.5.1 -> 8.5.2
* [`977ee466`](https://github.com/NixOS/nixpkgs/commit/977ee466ae48ec4a9d94541c928c24d7f3146672) solr: 8.5.2 -> 8.6.1
* [`776313e8`](https://github.com/NixOS/nixpkgs/commit/776313e8d157df6fee9710f53227335cce2eb0a0) zoneminder: fix CVE-2020-25729
* [`9d27d835`](https://github.com/NixOS/nixpkgs/commit/9d27d8357eef003f1ae13240847e696682309038) wolfssl: 4.4.0 -> 4.5.0
* [`674b4dd8`](https://github.com/NixOS/nixpkgs/commit/674b4dd8e3a80378924e7ff9af6a33e6c47cae4c) yed: 3.19.1.1 -> 3.20
* [`680cf571`](https://github.com/NixOS/nixpkgs/commit/680cf57169ce91a133bae49225375e65d25c7d14) yed: 3.20 -> 3.20.1
* [`25bc63ca`](https://github.com/NixOS/nixpkgs/commit/25bc63ca7b496dc41456f9fafb4d87f9e8398dd6) linux: 4.14.202 -> 4.14.203
* [`90a9f462`](https://github.com/NixOS/nixpkgs/commit/90a9f46240af5549ab0289f243fe614ce053c7a8) linux: 4.19.152 -> 4.19.153
* [`08acf534`](https://github.com/NixOS/nixpkgs/commit/08acf53426813ed5c7e60f8d8142fc1e275d8d9d) linux: 4.4.240 -> 4.4.241
* [`91cf7b74`](https://github.com/NixOS/nixpkgs/commit/91cf7b7481dbed125b3d9f6f7628c4de8746b654) linux: 4.9.240 -> 4.9.241
* [`27212188`](https://github.com/NixOS/nixpkgs/commit/27212188ee8072ee79a4633e95fb5c731d40e1c0) linux: 5.4.72 -> 5.4.73
* [`34e48e03`](https://github.com/NixOS/nixpkgs/commit/34e48e031306cd1c94b9adcad87ca3b675695aef) wire-desktop: linux 3.20.2934 -> 3.21.2936
* [`3343effc`](https://github.com/NixOS/nixpkgs/commit/3343effc326c3fb488f2130551d92bd553bed37c) wire-desktop: mac 3.20.3912 -> 3.21.3959
* [`291e3c6d`](https://github.com/NixOS/nixpkgs/commit/291e3c6d5c08370977073625532738f0aeaf67b5) linux: 4.19.153 -> 4.19.154
* [`050b0068`](https://github.com/NixOS/nixpkgs/commit/050b0068e5760d35c712fe4e77cc1cbf26c79640) matrix-synapse: 1.22.0 -> 1.22.1
* [`e09c7f0b`](https://github.com/NixOS/nixpkgs/commit/e09c7f0b1f80453d77687ff09fa4c396a25a6def) firefox: place alsaLib in lib search patch
* [`3b3b0d5b`](https://github.com/NixOS/nixpkgs/commit/3b3b0d5ba7b355eaf2a49f7ab362516c463ee559) openldap: add patch to fix unauthenticated nullptr dereference in slapd
* [`57b3ed6c`](https://github.com/NixOS/nixpkgs/commit/57b3ed6c471833a705a98b273871a9d5af635983) youtube-dl: 2020-09-20 -> 2020.11.01.1
* [`fbd345dd`](https://github.com/NixOS/nixpkgs/commit/fbd345dd005222eed9cf27d724cc7abdd54c048f) linux: 5.4.73 -> 5.4.74
* [`34883479`](https://github.com/NixOS/nixpkgs/commit/34883479d7e3a3fb56b6bb708b56e3c1143a8dfa) salt: 2019.2.4 -> 2019.2.7
* [`90c1c405`](https://github.com/NixOS/nixpkgs/commit/90c1c4056ce5e2f28c66b59605ba02c3d8416b3b) chromiumDev: 88.0.4292.2 -> 88.0.4298.4
* [`d2f46002`](https://github.com/NixOS/nixpkgs/commit/d2f46002829c80756f19a36abd58a3a25f0cc202) chromium: 86.0.4240.111 -> 86.0.4240.183
* [`d6582d88`](https://github.com/NixOS/nixpkgs/commit/d6582d8876717abef5c8e0b18cfac7b72f66e82c) motion: fix CVE-2020-26566
* [`d70b1e2d`](https://github.com/NixOS/nixpkgs/commit/d70b1e2d2dd2d4030cd35b3b7ad85755951af506) ant: 1.9.6 -> 1.9.15
* [`1fbed80d`](https://github.com/NixOS/nixpkgs/commit/1fbed80dfe808e5dc488598f253653dcf61b70c0) axel: 2.17.7 -> 2.17.8
* [`5619d39e`](https://github.com/NixOS/nixpkgs/commit/5619d39e1db293cf5ada3e4eed34f20fb2769928) axel: 2.17.8 -> 2.17.9
* [`32d313ff`](https://github.com/NixOS/nixpkgs/commit/32d313ffb644bd74ede8823852973c39d2c6eaa2) balsa: 2.5.9 -> 2.5.11
* [`75bde932`](https://github.com/NixOS/nixpkgs/commit/75bde932668e31b002a2204f2a2c1a51e4e0231e) linux: 4.14.203 -> 4.14.204
* [`3f3186c7`](https://github.com/NixOS/nixpkgs/commit/3f3186c76bb8d0c9b47c15a453eb1087106ee7d3) linux: 4.19.154 -> 4.19.155
* [`688286e5`](https://github.com/NixOS/nixpkgs/commit/688286e5e9ce2339b2a77fbeae258c23730bcbd1) linux: 5.4.74 -> 5.4.75
* [`e138b425`](https://github.com/NixOS/nixpkgs/commit/e138b425eaf0043f730763eed653088ef364293f) tmux: apply patch for CVE-2020-27347
* [`b63c2351`](https://github.com/NixOS/nixpkgs/commit/b63c23511c02b0d00fd084712a463c0d1f1d5f4c) singularity: 3.6.1 -> 3.6.4
* [`18f8c1fe`](https://github.com/NixOS/nixpkgs/commit/18f8c1fe060bee2dcc6cf8e1b27f2acab689f457) libexif: apply patches for CVE-2020-0198, CVE-2020-0452
* [`9dc018ca`](https://github.com/NixOS/nixpkgs/commit/9dc018cac988dba488c82a7397336b954310f83d) element-web: 1.7.12 -> 1.7.13
* [`2257e6cf`](https://github.com/NixOS/nixpkgs/commit/2257e6cf4d7fe7d0618ae4a040799a8604e186e5) element-desktop: 1.7.12 -> 1.7.13
* [`c80ec279`](https://github.com/NixOS/nixpkgs/commit/c80ec279296b06ba24ab0d98164f25237d4564f9) linux: 4.14.204 -> 4.14.205
* [`626729bd`](https://github.com/NixOS/nixpkgs/commit/626729bdfe7c123ee93883682082ffcb362de1f0) linux: 4.19.155 -> 4.19.156
* [`276fcac1`](https://github.com/NixOS/nixpkgs/commit/276fcac12bb288cc212d55a64ae8a28071831547) linux: 4.4.241 -> 4.4.242
* [`6bb461e6`](https://github.com/NixOS/nixpkgs/commit/6bb461e607afcd637415cb6af3b8a3d350bc7728) linux: 4.9.241 -> 4.9.242
* [`336baf0d`](https://github.com/NixOS/nixpkgs/commit/336baf0d0987800c7e1441485f3849299122e8bf) linux: 5.4.75 -> 5.4.76
* [`30e67e96`](https://github.com/NixOS/nixpkgs/commit/30e67e965c469bac10ccdfd160a930244cb6557c) linuxPackages.wireguard: fix the build on linux 5.4.76
* [`f341eb27`](https://github.com/NixOS/nixpkgs/commit/f341eb2728ca735f4ab4556b6562316098e05a25) nats-server: 2.1.0 -> 2.1.7
* [`3b28e23a`](https://github.com/NixOS/nixpkgs/commit/3b28e23a04cbe69d34611c85724656f5576c6c03) nats-server: 2.1.7 -> 2.1.9
* [`67d9c40c`](https://github.com/NixOS/nixpkgs/commit/67d9c40ccd4d86c1f702ceca2eadd519916c4cba) chromium: Extend update.py to automatically update gn
* [`abe53c31`](https://github.com/NixOS/nixpkgs/commit/abe53c3191b5951772bc3564f45e5da10003ac02) chromium: 86.0.4240.183 -> 86.0.4240.193
* [`6e3ca0f8`](https://github.com/NixOS/nixpkgs/commit/6e3ca0f8cc937cea5d6e581d38773f95bada8c29) linux: 4.14.205 -> 4.14.206
* [`838e06da`](https://github.com/NixOS/nixpkgs/commit/838e06daba5e68a2cbebcdd6d01f61a12bafe12b) linux: 4.19.156 -> 4.19.157
* [`e4f15b2f`](https://github.com/NixOS/nixpkgs/commit/e4f15b2fa685ad6b6b19248e31ba7717c4b06655) linux: 4.4.242 -> 4.4.243
* [`c539e2fc`](https://github.com/NixOS/nixpkgs/commit/c539e2fced95f70262ab4f53dc6a7977cfe670b5) linux: 4.9.242 -> 4.9.243
* [`5d820315`](https://github.com/NixOS/nixpkgs/commit/5d820315cd08bef23e276deebdc9f6ee32704dbf) linux: 5.4.76 -> 5.4.77
* [`b5f0a7db`](https://github.com/NixOS/nixpkgs/commit/b5f0a7db0563ad584a0cc78416fddc9d595efc5c) chromium: 86.0.4240.193 -> 86.0.4240.198
* [`9315a5fc`](https://github.com/NixOS/nixpkgs/commit/9315a5fcd82c696ba51ee84d72bba1b400f48699) tor-browser-bundle-bin: Fix extension path.  Fixes NoScript.
* [`16b3b1ee`](https://github.com/NixOS/nixpkgs/commit/16b3b1eef03e6fb8211b095079aba5059f26081e) tor-browser-bundle-bin: 10.0.2 -> 10.0.4
* [`51105e33`](https://github.com/NixOS/nixpkgs/commit/51105e33db6efa6dbe3dd7b25ecfa02aefe391f5) librdf_raptor2: add patch for CVE-2017-18926
* [`18a94f81`](https://github.com/NixOS/nixpkgs/commit/18a94f814f6e625e8eb3118ec14a7149daf1e61a) microcodeIntel: 20200616 -> 20201110
* [`bad3f7b6`](https://github.com/NixOS/nixpkgs/commit/bad3f7b693beedbd9dea34f75ef133ce5ba2f23d) microcodeIntel: 20201110 -> 20201112
* [`9a6c02e8`](https://github.com/NixOS/nixpkgs/commit/9a6c02e8a006a04a9d9ebc7784afba6a827e5a9e) go_1_14: 1.14.8 -> 1.14.9
* [`d36da9ac`](https://github.com/NixOS/nixpkgs/commit/d36da9ac6f2df77c0a5e46a48f0a03959571d43b) go_1_14: 1.14.9 -> 1.14.10
* [`590e678b`](https://github.com/NixOS/nixpkgs/commit/590e678b8e2e7c77552edb11b4530a3172ea6ac6) go_1_14: 1.14.10 -> 1.14.11
* [`7abaad0d`](https://github.com/NixOS/nixpkgs/commit/7abaad0dc9bb320c5af5b9d473231878c670235e) go_1_14: 1.14.11 -> 1.14.12
* [`db46d7b2`](https://github.com/NixOS/nixpkgs/commit/db46d7b20ad74f15a937c94196308d2d18b855bc) youtube-dl: 2020.11.01.1 -> 2020.11.12
* [`4c72e033`](https://github.com/NixOS/nixpkgs/commit/4c72e033dea4e51e09a2628310d8f1fb7273d160) firefox: 82.0.2 -> 82.0.3
* [`30880c92`](https://github.com/NixOS/nixpkgs/commit/30880c92757532b1eefee42793bcea3807565b87) firefox-esr: 78.4.0esr -> 78.4.1esr
* [`c1118dae`](https://github.com/NixOS/nixpkgs/commit/c1118dae75393fbe8b721432c3430be092e74ec5) firefox-bin: 82.0 -> 82.0.2
* [`497b6020`](https://github.com/NixOS/nixpkgs/commit/497b6020c271750d531f077d7e0c0cc2ba31bc79) firefox-bin: 82.0.2 -> 82.0.3
* [`dcffaeda`](https://github.com/NixOS/nixpkgs/commit/dcffaedac7bfd26b6fdbfa09030908629467ff57) firefox-bin: 82.0.3 -> 83.0
* [`b88fbf2a`](https://github.com/NixOS/nixpkgs/commit/b88fbf2abd5d80b51718cd2db4ab7cbdb722ca09) linux: 4.14.206 -> 4.14.207
* [`31cf3b3c`](https://github.com/NixOS/nixpkgs/commit/31cf3b3caa08bbadca90a3c25cd8eb4529e29a5d) linux: 4.19.157 -> 4.19.158
* [`60003aa6`](https://github.com/NixOS/nixpkgs/commit/60003aa6e5e843db95b5cb98171ea3e2ec427e05) linux: 4.4.243 -> 4.4.244
* [`7fc57f20`](https://github.com/NixOS/nixpkgs/commit/7fc57f2020ca1d4e70ff4dfb9c2dd0e67ecced39) linux: 4.9.243 -> 4.9.244
* [`d488daf8`](https://github.com/NixOS/nixpkgs/commit/d488daf8504ef1838c6b89f7add9bf370757afe4) linux: 5.4.77 -> 5.4.78
* [`864a73be`](https://github.com/NixOS/nixpkgs/commit/864a73be91b204482042c5ab3bcb62059c945f0c) openldap: apply security patches
* [`7deaa010`](https://github.com/NixOS/nixpkgs/commit/7deaa010f98da458e4e61b5303928ba2e065f793) chromium: 86.0.4240.198 -> 87.0.4280.66
* [`c2967aeb`](https://github.com/NixOS/nixpkgs/commit/c2967aeb05a986966c34923c69f9ade325b2b1eb) neomutt: apply patch to mitigate CVE-2020-28896
* [`e1e6b259`](https://github.com/NixOS/nixpkgs/commit/e1e6b25924150d81b5abe1270ef4218ce7816e3a) thunderbird-bin: 78.4.0 -> 78.4.1
* [`a4c4b509`](https://github.com/NixOS/nixpkgs/commit/a4c4b509fc54d615ea0372a46e0122c73d41eeb8) thunderbird: 78.4.0 -> 78.4.1
* [`bd561c83`](https://github.com/NixOS/nixpkgs/commit/bd561c832ae5c619adb9301101584643c91fc8f4) thunderbird-bin: 78.4.1 -> 78.4.2
* [`aa5c3429`](https://github.com/NixOS/nixpkgs/commit/aa5c34294f66694d40a32ce77b3ce3c53f5755ff) thunderbird: 78.4.1 -> 78.4.2
* [`5a2ff043`](https://github.com/NixOS/nixpkgs/commit/5a2ff043f456ab05c0014e6a500f1fa1a35d9b50) thunderbird-bin: 78.4.2 -> 78.4.3
* [`b1f30a63`](https://github.com/NixOS/nixpkgs/commit/b1f30a632889fe2577123de247b47b73e4461f3c) thunderbird: 78.4.2 -> 78.4.3
* [`a49b9a2d`](https://github.com/NixOS/nixpkgs/commit/a49b9a2d476e4e23a0c5d0240902cd5a96fd3daf) thunderbird-bin: 78.4.3 -> 78.5.0
* [`95828400`](https://github.com/NixOS/nixpkgs/commit/95828400333a173f5ca1cbe37b99813503e63ab6) thunderbird: 78.4.3 -> 78.5.0
* [`8fdb672c`](https://github.com/NixOS/nixpkgs/commit/8fdb672c6a2cde3870d72ccc1dc1d2b118fd79d7) opencv3, opencv4: use openblasCompat
* [`8f902278`](https://github.com/NixOS/nixpkgs/commit/8f9022789211d6be645e5f97a258e0b6e9e24c9e) glfw: 3.3.1 -> 3.3.2
* [`4586b2f0`](https://github.com/NixOS/nixpkgs/commit/4586b2f0d0cce2916766dfcd1b717c0940d865ef) mutt: apply patch for CVE-2020-28896
* [`8e81f8f6`](https://github.com/NixOS/nixpkgs/commit/8e81f8f66b2910f053b5e70e5ce34e5403dfc1e1) linux: 4.14.207 -> 4.14.208
* [`096bad8d`](https://github.com/NixOS/nixpkgs/commit/096bad8d75f1445e622d07faccce2e8ff43956c5) linux: 4.19.158 -> 4.19.159
* [`0b98507d`](https://github.com/NixOS/nixpkgs/commit/0b98507d9ed5d76897194796b2ec93fb9e1e9fed) linux: 4.4.244 -> 4.4.245
* [`690441cc`](https://github.com/NixOS/nixpkgs/commit/690441cccc723346c568e2ecac985140ae062d86) linux: 4.9.244 -> 4.9.245
* [`9dba1258`](https://github.com/NixOS/nixpkgs/commit/9dba125845433fb0d2a4edb9f3e9e75a836abc15) linux: 5.4.78 -> 5.4.79
* [`bf14ca43`](https://github.com/NixOS/nixpkgs/commit/bf14ca43fc709ad78fbc30ae51e5658c16e883ca) linux: 4.14.208 -> 4.14.209
* [`9d4d0ffd`](https://github.com/NixOS/nixpkgs/commit/9d4d0ffd41c784caeceee319e59d8404b042c7bf) linux: 4.19.159 -> 4.19.160
* [`df1c3b4e`](https://github.com/NixOS/nixpkgs/commit/df1c3b4ef9f33a97f8cb5e5e565cc3da8d92728f) linux: 4.4.245 -> 4.4.246
* [`12d4eedc`](https://github.com/NixOS/nixpkgs/commit/12d4eedc6ec9634fe5605479702f530ab526a6c7) linux: 4.9.245 -> 4.9.246
* [`d1b07d4c`](https://github.com/NixOS/nixpkgs/commit/d1b07d4cc4272e23a45fb2be414abf1b937fbacf) linux: 5.4.79 -> 5.4.80
* [`16ee69c8`](https://github.com/NixOS/nixpkgs/commit/16ee69c8720b8a96f4d0935d0688d4e4d6df52db) sddm: add patch for CVE-2020-28049
* [`9518fac7`](https://github.com/NixOS/nixpkgs/commit/9518fac712ca001009bd12a3c94621f1ee805657) opensc: 0.20.0 -> 0.21.0
* [`df25e214`](https://github.com/NixOS/nixpkgs/commit/df25e214c8e662d693ef89e45ce56bbf58d6c59e) microcodeIntel: 20201112 -> 20201118
* [`48f4ff86`](https://github.com/NixOS/nixpkgs/commit/48f4ff86684d8fd69db9a1858efcd4a851d75eae) linux: 4.14.209 -> 4.14.210
* [`3b81ad9a`](https://github.com/NixOS/nixpkgs/commit/3b81ad9a4d0a22a41ed7833509b04ef632b41652) linux: 4.19.160 -> 4.19.161
* [`080f698b`](https://github.com/NixOS/nixpkgs/commit/080f698b5debff849aaf8d46fd43ea7320d5d34a) linux: 4.4.246 -> 4.4.247
* [`3bd3b62c`](https://github.com/NixOS/nixpkgs/commit/3bd3b62c132aea597c80ff14d5b9b2ae9a8e933e) linux: 4.9.246 -> 4.9.247
* [`0f8a31b9`](https://github.com/NixOS/nixpkgs/commit/0f8a31b992b6892dd075bac8533955a9b92ac9df) linux: 5.4.80 -> 5.4.81
* [`f577872a`](https://github.com/NixOS/nixpkgs/commit/f577872afb1bd17aa43419152230aabfc8c8d5bf) slurm: 19.05.7.1 -> 19.05.8.1
