### PR TITLE
niv nixpkgs-static: update 38215029 -> 217a812d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nh2",
         "repo": "static-haskell-nix",
-        "rev": "382150290ba43b6eb41981c1ab3b32aa31798140",
-        "sha256": "0zsyplzf1k235rl26irm27y5ljd8ciayw80q575msxa69a9y2nvd",
+        "rev": "217a812de7387d3f056cc6fc4d861f52d6afa3ca",
+        "sha256": "0ba2jqi25p01jmd827xkw05wrv40pa46vh3j0dvyx6b6bsyj4xqx",
         "type": "tarball",
-        "url": "https://github.com/nh2/static-haskell-nix/archive/382150290ba43b6eb41981c1ab3b32aa31798140.tar.gz",
+        "url": "https://github.com/nh2/static-haskell-nix/archive/217a812de7387d3f056cc6fc4d861f52d6afa3ca.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
## Changelog for nixpkgs-static:
Branch: master
Commits: [nh2/static-haskell-nix@38215029...217a812d](https://github.com/nh2/static-haskell-nix/compare/382150290ba43b6eb41981c1ab3b32aa31798140...217a812de7387d3f056cc6fc4d861f52d6afa3ca)

* [`e75cff5e`](https://github.com/nh2/static-haskell-nix/commit/e75cff5e6293eb09750da1350d364470b5117fa6) nixpkgs: Update submodule:
* [`7f3bdc9e`](https://github.com/nh2/static-haskell-nix/commit/7f3bdc9e782a54c75c3fe3ebb721630adc5e8a96) Some fixes for building static `curl`.
* [`a857b034`](https://github.com/nh2/static-haskell-nix/commit/a857b034fdc586640d6a4d087fdc6d97eb176daf) survey: Add / default to ghc8104
* [`614cb584`](https://github.com/nh2/static-haskell-nix/commit/614cb5840e93202ba99960a2370a85ea3ea6c22e) Don't build ghc twice when Cabal patches aren't required
* [`bd43b78e`](https://github.com/nh2/static-haskell-nix/commit/bd43b78ea47dd5d07fa603063f0b2d54c0832671) Fix ncurses `recompile with -fpic` error on some packages
* [`4daf7410`](https://github.com/nh2/static-haskell-nix/commit/4daf7410ed5768da36c6df36bbf600cddb9c2a57) survey: Disable some tests. `-A working` now builds with GHC 8.10.4
* [`c3feae38`](https://github.com/nh2/static-haskell-nix/commit/c3feae38357c25af3488050f37f403c8135272bf) survey: Disable aura for now because aur is marked broken in nixpkgs
* [`b575564a`](https://github.com/nh2/static-haskell-nix/commit/b575564a027f1582674f245d756c2a694f36a9a5) Disable flaky `time-compat` tests.
* [`047e51b0`](https://github.com/nh2/static-haskell-nix/commit/047e51b0cd2f0587a213f480e38a1296c30a9988) survey: add dhall-json to the working set
* [`864d1a2a`](https://github.com/nh2/static-haskell-nix/commit/864d1a2a1792577324dbfc6a211d963cdfec2a61) survey: Disable slow `aeson-diff` test suite on `-O0`
* [`27a60286`](https://github.com/nh2/static-haskell-nix/commit/27a6028622c7d737690ade0ec674a2b78d7b2bde) survey: Disable stripping to work around `strip` 300x performance regression
* [`2d194149`](https://github.com/nh2/static-haskell-nix/commit/2d1941493ad2a2ba03ef82bca7718953db1ebfa5) survey: Rename `dont-distribute-packages` -> `stackage-packages`.
* [`fdaa9df7`](https://github.com/nh2/static-haskell-nix/commit/fdaa9df73b306e7ec3de3380212b9772cb02f91e) survey: Drastically simplify/improve stackage brokenness check.
* [`eca2fcc9`](https://github.com/nh2/static-haskell-nix/commit/eca2fcc9c74328a475bc594d1048c55bf1ef46b8) survey: add proto3-suite to the working set
* [`adeee4b3`](https://github.com/nh2/static-haskell-nix/commit/adeee4b3f51bfd029aeb63f581917042a32fd380) survey: allStackageExecutables: Strip down dependency tree
* [`0dbea166`](https://github.com/nh2/static-haskell-nix/commit/0dbea166dca4f16eb3cf093cb4e8ddedebf2b516) survey: Add more ghc -> cabal version mappings.
* [`c25d7ac2`](https://github.com/nh2/static-haskell-nix/commit/c25d7ac21a1de815a810437b722024760504445b) Fix `-A workingStackageExecutables` not building on GHC 8.10.4
* [`7a3992bc`](https://github.com/nh2/static-haskell-nix/commit/7a3992bc62a5b5acc2ee34d227259cc83ba5efac) survey: Fix `-A working -A workingStackageExecutables` with `-O0`.
* [`1f557c24`](https://github.com/nh2/static-haskell-nix/commit/1f557c24c0fc2a9b516dcb57c5255262f83198a6) Fix stack integration, use version of stack2nix that supports Stack 2.
* [`6e6ab1d0`](https://github.com/nh2/static-haskell-nix/commit/6e6ab1d0bf86acec0524175f8abb535e1312c167) survey: Exclude a flaky test
* [`25d95077`](https://github.com/nh2/static-haskell-nix/commit/25d950779a41efbba9e49044b35306887c3affd1) Fix buildkite `static-stack` action.
* [`165d2077`](https://github.com/nh2/static-haskell-nix/commit/165d2077854bb042c36ed8cd6a846a5efb3c7b91) Update example commits
* [`9ba2931a`](https://github.com/nh2/static-haskell-nix/commit/9ba2931ab6c7ef2ded6df923ed54c1293e4f7b7a) Refactor: Reformat `statify`
* [`217a812d`](https://github.com/nh2/static-haskell-nix/commit/217a812de7387d3f056cc6fc4d861f52d6afa3ca) survey: Only skip stripping `.a` files, not executables
