### PR TITLE
niv nixpkgs: update 030e2ce8 -> 1db42b7f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "030e2ce817c8e83824fb897843ff70a15c131b96",
-        "sha256": "110kgp4x5bx44rgw55ngyhayr4s19xwy19n6qw9g01hvhdisilwf",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "sha256": "05k9y9ki6jhaqdhycnidnk5zrdzsdammbk5lsmsbz249hjhhgcgh",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/030e2ce817c8e83824fb897843ff70a15c131b96.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/1db42b7fe3878f3f5f7a4f2dc210772fd080e205.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-static": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: nixos-20.03
Commits: [NixOS/nixpkgs@030e2ce8...1db42b7f](https://github.com/NixOS/nixpkgs/compare/030e2ce817c8e83824fb897843ff70a15c131b96...1db42b7fe3878f3f5f7a4f2dc210772fd080e205)

* [`634d5aa8`](https://github.com/NixOS/nixpkgs/commit/634d5aa86c29937f99a9076827ad4ec7ed6c1589) linux: 4.14.210 -> 4.14.212
* [`09fd4805`](https://github.com/NixOS/nixpkgs/commit/09fd4805c66699dfccac97f193b8e8e7aae23ea7) linux: 4.19.161 -> 4.19.163
* [`8cd43f2f`](https://github.com/NixOS/nixpkgs/commit/8cd43f2f57393fde10acd5efae0809e85185af5a) linux: 4.4.247 -> 4.4.248
* [`18a87f74`](https://github.com/NixOS/nixpkgs/commit/18a87f748912b3cd6e3450963a56ff8ef4ecda5a) linux: 4.9.247 -> 4.9.248
* [`7f73e466`](https://github.com/NixOS/nixpkgs/commit/7f73e46625f508a793700f5110b86f1a53341d6e) linux: 5.4.81 -> 5.4.83
* [`92976826`](https://github.com/NixOS/nixpkgs/commit/929768261a3ede470eafb58d5b819e1a848aa8bf) linux: 5.4.83 -> 5.4.84
* [`462c6fe4`](https://github.com/NixOS/nixpkgs/commit/462c6fe4b115804ea4d5bee7103c0f46ff9f9cfb) [nixos/prometheus] promTypes.filter.value -> promTypes.filter.values
* [`9ef94a10`](https://github.com/NixOS/nixpkgs/commit/9ef94a105ffe8fc1be4a9e304b8ebcc3f1a0b2c0) curl: fix hash mismatch issue by directly include CVE patches
* [`6d1a044f`](https://github.com/NixOS/nixpkgs/commit/6d1a044fc9ff3cc96fca5fa3ba9c158522bbf2a5) pythonPackages.hetzner: 0.8.2 -> 0.8.3
* [`f251766a`](https://github.com/NixOS/nixpkgs/commit/f251766a219f7f32eca08567f663f0eb8e6a4968) perlPackages.ImageExifTool: apply fix for CVE-2021-22204
