### PR TITLE
niv nixpkgs-static: update 217a812d -> bd66b86b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nh2",
         "repo": "static-haskell-nix",
-        "rev": "217a812de7387d3f056cc6fc4d861f52d6afa3ca",
-        "sha256": "0ba2jqi25p01jmd827xkw05wrv40pa46vh3j0dvyx6b6bsyj4xqx",
+        "rev": "bd66b86b72cff4479e1c76d5916a853c38d09837",
+        "sha256": "0rnsxaw7v27znsg9lgqk1i4007ydqrc8gfgimrmhf24lv6galbjh",
         "type": "tarball",
-        "url": "https://github.com/nh2/static-haskell-nix/archive/217a812de7387d3f056cc6fc4d861f52d6afa3ca.tar.gz",
+        "url": "https://github.com/nh2/static-haskell-nix/archive/bd66b86b72cff4479e1c76d5916a853c38d09837.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
## Changelog for nixpkgs-static:
Branch: master
Commits: [nh2/static-haskell-nix@217a812d...bd66b86b](https://github.com/nh2/static-haskell-nix/compare/217a812de7387d3f056cc6fc4d861f52d6afa3ca...bd66b86b72cff4479e1c76d5916a853c38d09837)

* [`27a5f501`](https://github.com/nh2/static-haskell-nix/commit/27a5f50100ab9587bb34b5dabb8d8f447dc541b5) Update example commits
* [`8ef5f6e8`](https://github.com/nh2/static-haskell-nix/commit/8ef5f6e812fcedc34888db9858a86d3cea5739fb) nixpkgs: Update submodule to nixos-unstable with ghc musl fixes merged
* [`be23644f`](https://github.com/nh2/static-haskell-nix/commit/be23644fa49bbf9162798e119cfcd0607fb362dc) survey: No need to use musl based Python for stackage yaml parsing
* [`f27d2d39`](https://github.com/nh2/static-haskell-nix/commit/f27d2d39f6e2414ab06b44d2ea868a48f2ac8e56) Fix typo in comment
* [`4891576e`](https://github.com/nh2/static-haskell-nix/commit/4891576e5bc5e73a140116d123389a25a13b79e6) survey: Disable long-running test
* [`0e72ef1b`](https://github.com/nh2/static-haskell-nix/commit/0e72ef1ba53a4db633862cae231fb90a1e052a02) survey: Remove Cython overlay for Python 2.
* [`bd66b86b`](https://github.com/nh2/static-haskell-nix/commit/bd66b86b72cff4479e1c76d5916a853c38d09837) Update example commits
